### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "license": "MIT",
   "preferGlobal": "true",
   "dependencies": {
-    "glsl-tokenizer": "0.0.6",
-    "glsl-parser": "0.0.1",
-    "nopt": "~2.0.0",
-    "glsl-deparser": "0.0.1",
-    "glsl-min-stream": "0.0.2",
-    "cssauron": "0.0.2",
-    "cssauron-glsl": "0.0.0",
-    "through": "~1.1.2"
+    "glsl-tokenizer": "1.1.1",
+    "glsl-parser": "1.0.1",
+    "nopt": "~3.0.1",
+    "glsl-deparser": "1.0.0",
+    "glsl-min-stream": "1.0.0",
+    "cssauron": "~1.0.0",
+    "cssauron-glsl": "1.0.0",
+    "through": "2.3.4"
   }
 }


### PR DESCRIPTION
There is still some outdated in cssauron, glsl-deparser and glsl-min-stream:

```
Package   Current  Wanted  Latest  Location
cssauron    1.0.0   1.0.0   1.1.2  cssauron
cssauron    1.0.0   1.0.0   1.1.2  cssauron-glsl > cssauron
through     1.1.2   1.1.2   2.3.4  glsl-deparser > through
through     1.1.2   1.1.2   2.3.4  glsl-min-stream > through
```
